### PR TITLE
[TASK] remove auto-generated fields

### DIFF
--- a/Configuration/TCA/tx_mdnewsauthor_domain_model_newsauthor.php
+++ b/Configuration/TCA/tx_mdnewsauthor_domain_model_newsauthor.php
@@ -1,8 +1,6 @@
 <?php
 defined('TYPO3') or die();
 
-$versionInformation = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
-
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:md_news_author/Resources/Private/Language/locallang_db.xlf:tx_mdnewsauthor_domain_model_newsauthor',
@@ -83,89 +81,6 @@ return [
         ],
     ],
     'columns' => [
-
-        'sys_language_uid' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
-            'config' => [
-                'type' => 'language'
-            ],
-        ],
-        'l10n_parent' => [
-            'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'items' => [
-                    ['', 0],
-                ],
-                'foreign_table' => 'tx_mdnewsauthor_domain_model_newsauthor',
-                'foreign_table_where' => 'AND tx_mdnewsauthor_domain_model_newsauthor.pid=###CURRENT_PID### AND tx_mdnewsauthor_domain_model_newsauthor.sys_language_uid IN (-1,0)',
-            ],
-        ],
-        'l10n_diffsource' => [
-            'config' => [
-                'type' => 'passthrough',
-            ],
-        ],
-        't3ver_label' => [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.versionLabel',
-            'config' => [
-                'type' => 'input',
-                'size' => 30,
-                'max' => 255,
-            ]
-        ],
-        'hidden' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => [
-                'type' => 'check',
-                'renderType' => 'checkboxToggle',
-                'default' => 0,
-                'items' => $versionInformation->getMajorVersion() < 12 ? [
-                    [
-                        0 => '',
-                        1 => '',
-                    ],
-                ] : [
-                    ['label' => '', 'value' => ''],
-                ],
-            ],
-        ],
-        'starttime' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
-            'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'size' => 13,
-                'eval' => 'datetime,int',
-                'default' => 0,
-                'behaviour' => [
-                    'allowLanguageSynchronization' => true
-                ],
-            ],
-        ],
-        'endtime' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
-            'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'size' => 13,
-                'eval' => 'datetime,int',
-                'default' => 0,
-                'range' => [
-                    'upper' => mktime(0, 0, 0, 1, 1, 2038)
-                ],
-                'behaviour' => [
-                    'allowLanguageSynchronization' => true
-                ],
-            ],
-        ],
-
         'gender' => [
             'exclude' => true,
             'label' => 'LLL:EXT:md_news_author/Resources/Private/Language/locallang_db.xlf:tx_mdnewsauthor_domain_model_newsauthor.gender',


### PR DESCRIPTION
This cleans up a bit by removing TCA definitions for fields that TYPO3 auto-generates when used in `ctrl`

Fixes: cdaecke/md_news_author#22

Ref: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.3/Feature-85160-AutoCreateManagementDBFieldsFromTCACtrl.html
Ref: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html?highlight=t3ver_label